### PR TITLE
$VIRTUALENV/bin/python shouldn't be necessary

### DIFF
--- a/git-flake8
+++ b/git-flake8
@@ -2,6 +2,5 @@
 
 # git-flake8: run flake8 on Python files that have been changed or aren't added
 
-PYTHON=python
-[ -n "$VIRTUALENV" ] && PYTHON="$VIRTUALENV/bin/python"
+PYTHON="/usr/bin/env python"
 exec git ls-files --modified --others --exclude-standard -z '*.py' | xargs -0 "$PYTHON" -m flake8


### PR DESCRIPTION
Maybe even "python" would do the same thing - Since it's not the hashbang (the hashbang requires a path)
